### PR TITLE
CI: pin Ubuntu 24.04; use GCC 15 on Linux and Clang 21 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-25.04
             compiler: gcc-15
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-25.04-arm
             compiler: gcc-15
           - os: macos-latest
             compiler: clang-21
@@ -137,7 +137,7 @@ jobs:
 
   static-analysis:
     name: Static Analysis (clang-format, clang-tidy)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-25.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -255,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-25.04, ubuntu-25.04-arm]
         sanitizer: [asan, tsan, ubsan]
     steps:
       - name: Checkout
@@ -317,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-25.04, ubuntu-25.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-test:
-    name: Build & Test (${{ matrix.os }}, ${{ matrix.compiler }}, ${{ matrix.build_type }})
+    name: Build & Test (${{ matrix.os }}, ${{ matrix.build_type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -20,11 +20,8 @@ jobs:
         build_type: [Debug, RelWithDebInfo]
         include:
           - os: ubuntu-25.04
-            compiler: gcc-15
           - os: ubuntu-25.04-arm
-            compiler: gcc-15
           - os: macos-latest
-            compiler: clang-21
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,10 +33,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
-          # If gcc-15 isn’t present, add the toolchain PPA:
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
+          # Install GCC 15
+          sudo apt-get install -y gcc-15 g++-15
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -95,12 +90,13 @@ jobs:
           ccache --zero-stats || true
           ccache --max-size=500M || true
           EXTRA_CFG+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
-          # Select compiler per-OS: GCC 15 on Linux, Clang 21 on macOS
-          CC_BIN="gcc-15"
-          CXX_BIN="g++-15"
+          # Select compiler per-OS: Prefer GCC 15 on Linux (fallback to 14/13), Clang 21 on macOS
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             CC_BIN="$(brew --prefix llvm@21)/bin/clang"
             CXX_BIN="$(brew --prefix llvm@21)/bin/clang++"
+          else
+            CC_BIN="gcc-15"
+            CXX_BIN="g++-15"
           fi
           cmake -S . -B build \
             -G "${CMAKE_GENERATOR}" \
@@ -268,10 +264,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
-          # If gcc-15 isn’t present, add the toolchain PPA:
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
+          # Install GCC 15
+          sudo apt-get install -y gcc-15 g++-15
+          # Install sanitizer runtimes (try multiple versions, ignore failures)
+          sudo apt-get install -y libasan12 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -293,11 +289,14 @@ jobs:
             tsan)  EXTRA_FLAGS+=(-DMINNAL_ENABLE_TSAN=ON) ;;
             ubsan) EXTRA_FLAGS+=(-DMINNAL_ENABLE_UBSAN=ON) ;;
           esac
+          # Detect installed GCC (prefer 15, then 14, then 13)
+          CC_BIN="gcc-15"
+          CXX_BIN="g++-15"
           cmake -S . -B build-san \
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPG_CONFIG="${PG_CONFIG}" \
-            -DCMAKE_C_COMPILER="gcc-15" -DCMAKE_CXX_COMPILER="g++-15" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
             "${EXTRA_FLAGS[@]}"
 
       - name: Build (sanitizer)
@@ -329,10 +328,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
-          # If gcc-15 isn’t present, add the toolchain PPA:
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
+          # Install GCC 15
+          sudo apt-get install -y gcc-15 g++-15
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -347,11 +344,14 @@ jobs:
 
       - name: Configure (coverage flags)
         run: |
+          # Detect installed GCC (prefer 15, then 14, then 13)
+          CC_BIN="gcc-15"
+          CXX_BIN="g++-15"
           cmake -S . -B build-cov \
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPG_CONFIG="${PG_CONFIG}" \
-            -DCMAKE_C_COMPILER="gcc-15" -DCMAKE_CXX_COMPILER="g++-15" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
             -DCMAKE_C_FLAGS="--coverage" \
             -DCMAKE_CXX_FLAGS="--coverage" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        compiler: [gcc]
         build_type: [Debug, RelWithDebInfo]
+        include:
+          - os: ubuntu-24.04
+            compiler: gcc-15
+          - os: ubuntu-24.04-arm
+            compiler: gcc-15
+          - os: macos-latest
+            compiler: clang-21
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up LLVM (Clang 20)
-        if: matrix.compiler == 'clang'
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "20"
-
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
-        shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
+          # If gcc-15 isn’t present, add the toolchain PPA:
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -54,8 +56,9 @@ jobs:
         run: |
           set -euo pipefail
           brew update
-          brew install ninja ccache jq postgresql@17
+          brew install ninja ccache jq postgresql@17 llvm@21
           echo "$(brew --prefix ccache)/libexec" >> $GITHUB_PATH
+          echo "$(brew --prefix llvm@21)/bin" >> $GITHUB_PATH
 
       - name: Locate pg_config (Linux/macOS)
         shell: bash
@@ -92,11 +95,19 @@ jobs:
           ccache --zero-stats || true
           ccache --max-size=500M || true
           EXTRA_CFG+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+          # Select compiler per-OS: GCC 15 on Linux, Clang 21 on macOS
+          CC_BIN="gcc-15"
+          CXX_BIN="g++-15"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            CC_BIN="$(brew --prefix llvm@21)/bin/clang"
+            CXX_BIN="$(brew --prefix llvm@21)/bin/clang++"
+          fi
           cmake -S . -B build \
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DPG_CONFIG="${PG_CONFIG}" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
             "${EXTRA_CFG[@]}"
 
       - name: Build
@@ -126,7 +137,7 @@ jobs:
 
   static-analysis:
     name: Static Analysis (clang-format, clang-tidy)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -244,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
         sanitizer: [asan, tsan, ubsan]
     steps:
       - name: Checkout
@@ -255,7 +266,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y ninja-build ccache software-properties-common wget gnupg lsb-release
+          sudo apt-get install -y \
+            ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
+          # If gcc-15 isn’t present, add the toolchain PPA:
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -281,6 +297,7 @@ jobs:
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPG_CONFIG="${PG_CONFIG}" \
+            -DCMAKE_C_COMPILER="gcc-15" -DCMAKE_CXX_COMPILER="g++-15" \
             "${EXTRA_FLAGS[@]}"
 
       - name: Build (sanitizer)
@@ -300,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -310,7 +327,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y ninja-build ccache gcc g++ lcov gcovr software-properties-common wget gnupg lsb-release
+          sudo apt-get install -y \
+            ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
+          # If gcc-15 isn’t present, add the toolchain PPA:
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -329,6 +351,7 @@ jobs:
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPG_CONFIG="${PG_CONFIG}" \
+            -DCMAKE_C_COMPILER="gcc-15" -DCMAKE_CXX_COMPILER="g++-15" \
             -DCMAKE_C_FLAGS="--coverage" \
             -DCMAKE_CXX_FLAGS="--coverage" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,10 +32,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
-          # If gcc-15 isn’t present, add the toolchain PPA:
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
+          # Install GCC 15
+          sudo apt-get install -y gcc-15 g++-15
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   analyze:
     name: CodeQL (C/C++)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-25.04
     env:
       CMAKE_GENERATOR: Ninja
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   analyze:
     name: CodeQL (C/C++)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CMAKE_GENERATOR: Ninja
     steps:
@@ -30,7 +30,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y ninja-build build-essential cmake software-properties-common wget gnupg lsb-release
+          sudo apt-get install -y \
+            ninja-build ccache jq lcov gcovr software-properties-common wget gnupg lsb-release
+          # If gcc-15 isn’t present, add the toolchain PPA:
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -55,7 +60,8 @@ jobs:
           cmake -S . -B build \
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DPG_CONFIG="${PG_CONFIG}"
+            -DPG_CONFIG="${PG_CONFIG}" \
+            -DCMAKE_C_COMPILER="gcc-15" -DCMAKE_CXX_COMPILER="g++-15"
       - name: Build
         run: cmake --build build -j
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,8 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y ninja-build ccache build-essential cmake software-properties-common wget gnupg lsb-release
-          # If gcc-15 isn’t present, add the toolchain PPA:
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
+          # Install GCC 15
+          sudo apt-get install -y gcc-15 g++-15
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            compiler: gcc
+          - os: ubuntu-24.04
+            compiler: gcc-15
           - os: macos-latest
-            compiler: gcc
+            compiler: clang-21
 
     steps:
       - name: Checkout
@@ -37,6 +37,10 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y ninja-build ccache build-essential cmake software-properties-common wget gnupg lsb-release
+          # If gcc-15 isn’t present, add the toolchain PPA:
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15 libasan8 libtsan2 libubsan1
           # Add PGDG repo to get PostgreSQL 17
           sudo install -d -m 0755 /usr/share/keyrings
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -53,8 +57,9 @@ jobs:
         run: |
           set -euo pipefail
           brew update
-          brew install ninja ccache cmake postgresql@17
+          brew install ninja ccache cmake postgresql@17 llvm@21
           echo "$(brew --prefix ccache)/libexec" >> $GITHUB_PATH
+          echo "$(brew --prefix llvm@21)/bin" >> $GITHUB_PATH
 
       - name: Locate pg_config (Linux/macOS)
         shell: bash
@@ -83,11 +88,19 @@ jobs:
           if [[ "$RUNNER_OS" != "Windows" ]]; then
             EXTRA_CFG+=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
           fi
+          # Select compiler per-OS: GCC 15 on Linux, Clang 21 on macOS
+          CC_BIN="gcc-15"
+          CXX_BIN="g++-15"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            CC_BIN="$(brew --prefix llvm@21)/bin/clang"
+            CXX_BIN="$(brew --prefix llvm@21)/bin/clang++"
+          fi
           cmake -S . -B build \
             -G "${CMAKE_GENERATOR}" \
             -DCMAKE_BUILD_TYPE=Release \
             -DMINNAL_ENABLE_IPO=ON \
             -DPG_CONFIG="${PG_CONFIG}" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             "${EXTRA_CFG[@]}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-25.04
             compiler: gcc-15
           - os: macos-latest
             compiler: clang-21

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pg_minnal ⚡️
 
 [![CI](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml)
-[![Linux x64](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-24.04%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20x64&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-24.04%2C%20gcc%2C%20RelWithDebInfo%29)
-[![Linux ARM](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-24.04-arm%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20ARM&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-24.04-arm%2C%20gcc%2C%20RelWithDebInfo%29)
+[![Linux x64](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-25.04%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20x64&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-25.04%2C%20gcc%2C%20RelWithDebInfo%29)
+[![Linux ARM](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-25.04-arm%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20ARM&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-25.04-arm%2C%20gcc%2C%20RelWithDebInfo%29)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15%2B-blue)](https://www.postgresql.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pg_minnal ⚡️
 
 [![CI](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml)
-[![Linux x64](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-latest%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20x64&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-latest%2C%20gcc%2C%20RelWithDebInfo%29)
+[![Linux x64](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-24.04%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20x64&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-24.04%2C%20gcc%2C%20RelWithDebInfo%29)
 [![Linux ARM](https://img.shields.io/github/actions/workflow/status/harikrishnan94/minnal/ci.yml?branch=main&job=Build%20%26%20Test%20%28ubuntu-24.04-arm%2C%20gcc%2C%20RelWithDebInfo%29&label=Linux%20ARM&logo=linux)](https://github.com/harikrishnan94/minnal/actions/workflows/ci.yml?query=branch%3Amain+Build%20%26%20Test%20%28ubuntu-24.04-arm%2C%20gcc%2C%20RelWithDebInfo%29)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15%2B-blue)](https://www.postgresql.org/)


### PR DESCRIPTION
- Replace ubuntu-latest with ubuntu-24.04 (x64/arm) for reproducible CI
- Use GCC 15 on Linux via toolchain PPA; set CMAKE_C/CXX_COMPILER
  explicitly
- Use Homebrew LLVM/Clang 21 on macOS; add to PATH; drop install-llvm
  action
- Install sanitizer runtimes and tools (jq, lcov, gcovr); wire
  sanitizer builds to GCC 15
- Run static-analysis on ubuntu-24.04
- Update codeql/release workflows and README to reflect toolchain
  changes